### PR TITLE
Adding option to setup where org-policies will be applied

### DIFF
--- a/modules/secure-cloud-run-security/README.md
+++ b/modules/secure-cloud-run-security/README.md
@@ -70,13 +70,16 @@ module "cloud_run_security" {
 |------|-------------|------|---------|:--------:|
 | decrypters | List of comma-separated owners for each key declared in set\_decrypters\_for. | `list(string)` | `[]` | no |
 | encrypters | List of comma-separated owners for each key declared in set\_encrypters\_for. | `list(string)` | `[]` | no |
+| folder\_id | The folder ID to apply the policy to. | `string` | `""` | no |
 | key\_name | Key name. | `string` | n/a | yes |
 | key\_protection\_level | The protection level to use when creating a version based on this template. Possible values: ["SOFTWARE", "HSM"] | `string` | `"HSM"` | no |
 | key\_rotation\_period | Period of key rotation in seconds. | `string` | `"2592000s"` | no |
 | keyring\_name | Keyring name. | `string` | n/a | yes |
 | kms\_project\_id | The project where KMS will be created. | `string` | n/a | yes |
 | location | The location where resources are going to be deployed. | `string` | n/a | yes |
+| organization\_id | The organization ID to apply the policy to. | `string` | `""` | no |
 | owners | List of comma-separated owners for each key declared in set\_owners\_for. | `list(string)` | `[]` | no |
+| policy\_for | Policy Root: set one of the following values to determine where the policy is applied. Possible values: ["project", "folder", "organization"]. | `string` | `"project"` | no |
 | prevent\_destroy | Set the prevent\_destroy lifecycle attribute on keys.. | `bool` | `true` | no |
 | serverless\_project\_id | The project where Cloud Run is going to be deployed. | `string` | n/a | yes |
 

--- a/modules/secure-cloud-run-security/org_policies.tf
+++ b/modules/secure-cloud-run-security/org_policies.tf
@@ -14,13 +14,21 @@
  * limitations under the License.
  */
 
+locals {
+  project      = var.policy_for == "project" ? var.serverless_project_id : ""
+  folder       = var.policy_for == "folder" ? var.folder_id : ""
+  organization = var.policy_for == "organization" ? var.organization_id : ""
+}
+
 module "cloudrun_allowed_ingress" {
   source  = "terraform-google-modules/org-policy/google"
   version = "~> 5.1"
 
+  policy_for        = var.policy_for
+  project_id        = local.project
+  folder_id         = local.folder
+  organization_id   = local.organization
   constraint        = "constraints/run.allowedIngress"
-  policy_for        = "project"
-  project_id        = var.serverless_project_id
   policy_type       = "list"
   allow             = ["is:internal-and-cloud-load-balancing"]
   allow_list_length = 1
@@ -30,8 +38,10 @@ module "cloudrun_allowed_vpc_egress" {
   source  = "terraform-google-modules/org-policy/google"
   version = "~> 5.1"
 
-  policy_for        = "project"
-  project_id        = var.serverless_project_id
+  policy_for        = var.policy_for
+  project_id        = local.project
+  folder_id         = local.folder
+  organization_id   = local.organization
   constraint        = "constraints/run.allowedVPCEgress"
   policy_type       = "list"
   allow             = ["private-ranges-only"]

--- a/modules/secure-cloud-run-security/variables.tf
+++ b/modules/secure-cloud-run-security/variables.tf
@@ -74,3 +74,21 @@ variable "decrypters" {
   type        = list(string)
   default     = []
 }
+
+variable "policy_for" {
+  description = "Policy Root: set one of the following values to determine where the policy is applied. Possible values: [\"project\", \"folder\", \"organization\"]."
+  type        = string
+  default     = "project"
+}
+
+variable "folder_id" {
+  description = "The folder ID to apply the policy to."
+  type        = string
+  default     = ""
+}
+
+variable "organization_id" {
+  description = "The organization ID to apply the policy to."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Hey Folks,

This pull request allows the customer to choose in which level (project, folder or organization) the secure-cloud-run org-policies will be applied.

Can you please take a look on it?
Thank you!