### PR TITLE
Adds requirements on secure-cloud-run-net module

### DIFF
--- a/modules/secure-cloud-run-net/README.md
+++ b/modules/secure-cloud-run-net/README.md
@@ -1,46 +1,24 @@
 # Secure Cloud Run Network
 
 This module handles the basic deployment network configurations for Cloud Run usage.
+When using a Shared VPC, you can chose where to create the VPC Connector.
+
+_Note:_ When using a single VPC you should provides VPC and Serverless project id with the same value and the value for `connector_on_host_project` variable must be `false`.
 
 The resources/services/activations/deletions that this module will create/trigger are:
 
 * Creates Firewall rules on your **VPC Project**.
+  * Serverless to VPC Connector
+  * VPC Connector to Serverless
+  * VPC Connector to LB
+  * VPC Connector Health Checks
 * Creates a sub network to VPC Connector usage purpose.
 * Creates Serverless Connector on your **VPC Project** or **Serverless Project**. Refer the comparison below:
   * Advantages of creating connectors in the [VPC Project](https://cloud.google.com/run/docs/configuring/connecting-shared-vpc#host-project)
   * Advantages of creating connectors in the [Serverless Project](https://cloud.google.com/run/docs/configuring/connecting-shared-vpc#service-projects)
-* Grant the necessary roles for Cloud Run are able to use VPC Connector on your VPC.
-
-## Requirements
-
-### Software
-
-The following dependencies must be available:
-
-* [Terraform](https://www.terraform.io/downloads.html) >= 0.13.0
-* [Terraform Provider for GCP][terraform-provider-gcp] plugin v3.53
-
-### APIs
-
-The Serverless and Network project with the following APIs enabled must be used to host the
-resources of this module:
-
-* Google VPC Access API: `vpcaccess.googleapis.com`
-* Compute API: `compute.googleapis.com`
-
-### Service Account
-
-A service account with one of the following roles must be used to provision
-the resources of this module:
-
-* Network Project
-  * Compute Shared VPC Admin: `roles/compute.xpnAdmin`
-  * Network Admin: `roles/compute.networkAdmin`
-  * Security Admin: `roles/compute.securityAdmin`
-  * Serverless VPC Access Admin: `roles/vpcaccess.admin`
-* Serverless Project
-  * Security Admin: `roles/compute.securityAdmin`
-  * Serverless VPC Access Admin: `roles/vpcaccess.admin`
+* Grant the necessary roles for Cloud Run are able to use VPC Connector on your Shared VPC when creating VPC Connector in host project.
+  * Grant Network User role to Cloud Services service account.
+  * Grant VPC Access User to Cloud Run Service Identity when deploying VPC Access.
 
 ## Usage
 
@@ -67,7 +45,7 @@ module "cloud_run_network" {
 | connector\_on\_host\_project | Connector is going to be created on the host project if true. When false, connector is going to be created on service project. For more information, access [documentation](https://cloud.google.com/run/docs/configuring/connecting-shared-vpc). | `bool` | `false` | no |
 | create\_subnet | The subnet will be created with the subnet\_name variable if true. When false, it will use the subnet\_name for the subnet. | `bool` | `true` | no |
 | flow\_sampling | Sampling rate of VPC flow logs. The value must be in [0,1]. Where 1.0 means all logs, 0.5 mean half of the logs and 0.0 means no logs are reported. | `number` | `1` | no |
-| ip\_cidr\_range | The range of internal addresses that are owned by this subnetwork. Provide this property when you create the subnetwork. For example, 10.0.0.0/8 or 192.168.0.0/16. Ranges must be unique and non-overlapping within a network. Only IPv4 is supported | `string` | n/a | yes |
+| ip\_cidr\_range | The range of internal addresses that are owned by the subnetwork and which is going to be used by VPC Connector. For example, 10.0.0.0/28 or 192.168.0.0/28. Ranges must be unique and non-overlapping within a network. Only IPv4 is supported. | `string` | n/a | yes |
 | location | The location where resources are going to be deployed. | `string` | n/a | yes |
 | serverless\_project\_id | The project where cloud run is going to be deployed. | `string` | n/a | yes |
 | shared\_vpc\_name | Shared VPC name which is going to be used to create Serverless Connector. | `string` | n/a | yes |
@@ -84,3 +62,34 @@ module "cloud_run_network" {
 | run\_identity\_services\_sa | Service Identity to run services. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Requirements
+
+### Software
+
+The following dependencies must be available:
+
+* [Terraform](https://www.terraform.io/downloads.html) >= 0.13.0
+* [Terraform Provider for GCP](https://github.com/terraform-providers/terraform-provider-google) plugin < 5.0
+
+### APIs
+
+The Serverless and Network project with the following APIs enabled must be used to host the
+resources of this module:
+
+* Google VPC Access API: `vpcaccess.googleapis.com`
+* Compute API: `compute.googleapis.com`
+
+### Service Account
+
+A service account with one of the following roles must be used to provision
+the resources of this module:
+
+* Network Project
+  * Compute Shared VPC Admin: `roles/compute.xpnAdmin`
+  * Network Admin: `roles/compute.networkAdmin`
+  * Security Admin: `roles/compute.securityAdmin`
+  * Serverless VPC Access Admin: `roles/vpcaccess.admin`
+* Serverless Project
+  * Security Admin: `roles/compute.securityAdmin`
+  * Serverless VPC Access Admin: `roles/vpcaccess.admin`

--- a/modules/secure-cloud-run-net/variables.tf
+++ b/modules/secure-cloud-run-net/variables.tf
@@ -51,7 +51,7 @@ variable "connector_on_host_project" {
 }
 
 variable "ip_cidr_range" {
-  description = "The range of internal addresses that are owned by this subnetwork. Provide this property when you create the subnetwork. For example, 10.0.0.0/8 or 192.168.0.0/16. Ranges must be unique and non-overlapping within a network. Only IPv4 is supported"
+  description = "The range of internal addresses that are owned by the subnetwork and which is going to be used by VPC Connector. For example, 10.0.0.0/28 or 192.168.0.0/28. Ranges must be unique and non-overlapping within a network. Only IPv4 is supported."
   type        = string
 }
 


### PR DESCRIPTION
This PR adds requirements and details of what is created by `secure-cloud-run-net` sub-module