### PR TITLE
fix: dev tools to 1.10 for Go 1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.8
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.10
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.7
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.8
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -89,4 +89,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.8'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.10'

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -89,4 +89,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.7'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.8'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.8'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.10'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.7'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.8'

--- a/examples/cloud_run_vpc_connector/network.tf
+++ b/examples/cloud_run_vpc_connector/network.tf
@@ -42,7 +42,7 @@ module "serverless_connector" {
   vpc_connectors = [{
     name            = "central-serverless"
     region          = "us-central1"
-    subnet_name     = "${module.vpc.subnets["us-central1/cloud-run-subnet"]["name"]}"
+    subnet_name     = module.vpc.subnets["us-central1/cloud-run-subnet"]["name"]
     host_project_id = var.project_id
     machine_type    = "e2-micro"
     min_instances   = 2

--- a/examples/secure_cloud_run/README.md
+++ b/examples/secure_cloud_run/README.md
@@ -71,7 +71,6 @@ This example assumes that below mentioned pre-requisites are in place before con
 | resource\_names\_suffix | A suffix to concat in the end of the network resources names. | `string` | `""` | no |
 | serverless\_project\_id | The project where cloud run is going to be deployed. | `string` | n/a | yes |
 | shared\_vpc\_name | Shared VPC name which is going to be re-used to create Serverless Connector. | `string` | n/a | yes |
-| ssl | Run load balancer on HTTPS and provision managed certificate with provided `domain`. | `bool` | `true` | no |
 | vpc\_project\_id | The project where shared vpc is. | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/secure_cloud_run/variables.tf
+++ b/examples/secure_cloud_run/variables.tf
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-variable "ssl" {
-  description = "Run load balancer on HTTPS and provision managed certificate with provided `domain`."
-  type        = bool
-  default     = true
-}
-
 variable "serverless_project_id" {
   description = "The project where cloud run is going to be deployed."
   type        = string

--- a/examples/secure_cloud_run_standalone/README.md
+++ b/examples/secure_cloud_run_standalone/README.md
@@ -70,7 +70,6 @@ This example assumes that below mentioned prerequisites are in place before cons
 | ingress\_policies | A list of all [ingress policies](https://cloud.google.com/vpc-service-controls/docs/ingress-egress-rules#ingress-rules-reference), each list object has a `from` and `to` value that describes ingress\_from and ingress\_to.<br><br>Example: `[{ from={ sources={ resources=[], access_levels=[] }, identities=[], identity_type="ID_TYPE" }, to={ resources=[], operations={ "SRV_NAME"={ OP_TYPE=[] }}}}]`<br><br>Valid Values:<br>`ID_TYPE` = `null` or `IDENTITY_TYPE_UNSPECIFIED` (only allow indentities from list); `ANY_IDENTITY`; `ANY_USER_ACCOUNT`; `ANY_SERVICE_ACCOUNT`<br>`SRV_NAME` = "`*`" (allow all services) or [Specific Services](https://cloud.google.com/vpc-service-controls/docs/supported-products#supported_products)<br>`OP_TYPE` = [methods](https://cloud.google.com/vpc-service-controls/docs/supported-method-restrictions) or [permissions](https://cloud.google.com/vpc-service-controls/docs/supported-method-restrictions). | <pre>list(object({<br>    from = any<br>    to   = any<br>  }))</pre> | `[]` | no |
 | org\_id | The organization ID. | `string` | n/a | yes |
 | parent\_folder\_id | The ID of a folder to host the infrastructure created in this example. | `string` | `""` | no |
-| serverless\_folder\_suffix | The suffix to be concat in the Serverless folder name fldr-serverless-<SUFFIX>. | `string` | `""` | no |
 
 ## Outputs
 

--- a/examples/secure_cloud_run_standalone/main.tf
+++ b/examples/secure_cloud_run_standalone/main.tf
@@ -39,7 +39,7 @@ module "secure_harness" {
   vpc_name                                    = "vpc-secure-cloud-run"
   subnet_ip                                   = "10.0.0.0/28"
   private_service_connect_ip                  = "10.3.0.5"
-  create_access_context_manager_access_policy = false
+  create_access_context_manager_access_policy = var.create_access_context_manager_access_policy
   access_context_manager_policy_id            = var.access_context_manager_policy_id
   access_level_members                        = var.access_level_members
   key_name                                    = "key-secure-artifact-registry"

--- a/examples/secure_cloud_run_standalone/variables.tf
+++ b/examples/secure_cloud_run_standalone/variables.tf
@@ -30,12 +30,6 @@ variable "parent_folder_id" {
   default     = ""
 }
 
-variable "serverless_folder_suffix" {
-  description = "The suffix to be concat in the Serverless folder name fldr-serverless-<SUFFIX>."
-  type        = string
-  default     = ""
-}
-
 variable "access_context_manager_policy_id" {
   description = "The id of the default Access Context Manager policy. Can be obtained by running `gcloud access-context-manager policies list --organization YOUR_ORGANIZATION_ID --format=\"value(name)\"`. This variable must be provided if `create_access_context_manager_access_policy` is set to `false`"
   type        = number

--- a/main.tf
+++ b/main.tf
@@ -105,7 +105,7 @@ resource "google_cloud_run_service" "main" {
     metadata {
       labels      = var.template_labels
       annotations = local.template_annotations
-      name        = var.generate_revision_name ? null : "${var.service_name}-${var.traffic_split.0.revision_name}"
+      name        = var.generate_revision_name ? null : "${var.service_name}-${var.traffic_split[0].revision_name}"
     } // metadata
   }   // template
 

--- a/modules/secure-cloud-run-core/variables.tf
+++ b/modules/secure-cloud-run-core/variables.tf
@@ -129,6 +129,7 @@ variable "owasp_rules" {
 
 variable "lb_name" {
   description = "Name for load balancer and associated resources."
+  type        = string
   default     = "tf-cr-lb"
 }
 

--- a/modules/secure-cloud-run-core/versions.tf
+++ b/modules/secure-cloud-run-core/versions.tf
@@ -26,6 +26,14 @@ terraform {
       source  = "hashicorp/google-beta"
       version = "< 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "< 4.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "< 1.0"
+    }
   }
   provider_meta "google" {
     module_name = "blueprints/terraform/terraform-google-cloud-run:secure-cloud-run-core/v0.4.0"

--- a/modules/secure-cloud-run-harness/versions.tf
+++ b/modules/secure-cloud-run-harness/versions.tf
@@ -26,6 +26,14 @@ terraform {
       source  = "hashicorp/google-beta"
       version = "< 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "< 4.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "< 1.0"
+    }
   }
 
   provider_meta "google" {

--- a/modules/secure-cloud-run-net/firewall.tf
+++ b/modules/secure-cloud-run-net/firewall.tf
@@ -22,7 +22,9 @@ locals {
 module "firewall_rules" {
   count = var.connector_on_host_project ? 0 : 1
 
-  source       = "terraform-google-modules/network/google//modules/firewall-rules"
+  source  = "terraform-google-modules/network/google//modules/firewall-rules"
+  version = "~> 6.0"
+
   project_id   = var.vpc_project_id
   network_name = var.shared_vpc_name
 


### PR DESCRIPTION
New updates from renovate bots requires Go 1.18 which is not available in Developer Tools 1.7.
Also closes duplicate PR #105 