### PR TITLE
fix : Correct the logic to accept the secrets as env variable.

### DIFF
--- a/modules/job-exec/main.tf
+++ b/modules/job-exec/main.tf
@@ -34,16 +34,16 @@ resource "google_cloud_run_v2_job" "job" {
           }
         }
 
-        dynamic "env" {
-          for_each = var.env_secret_vars
+	dynamic "env" {
+          for_each = var.cr_env_secret_vars
           content {
             name = env.value["name"]
-            dynamic "value_from" {
-              for_each = env.value.value_from
+            dynamic "value_source" {
+              for_each = env.value.value_source
               content {
-                secret_key_ref {
-                  name = value_from.value.secret_key_ref["name"]
-                  key  = value_from.value.secret_key_ref["key"]
+                secret_key_ref  {
+                  secret = value_source.value.secret_key_ref["secret"]
+		  version = value_source.value.secret_key_ref["version"]
                 }
               }
             }


### PR DESCRIPTION
When we are creating cloud run with reference of secrets this module failed with below error.
`
│ Error: Unsupported block type
│
│   on .terraform\modules\job\modules\job-exec\main.tf line 41, in resource "google_cloud_run_v2_job" "job":
│   41:             dynamic "value_from" {
│
│ Blocks of type "value_from" are not expected here.
╵
`
[Detailed Issue](https://stackoverflow.com/questions/76588520/structure-of-secrets-in-terraform-script-for-cloud-run-job?noredirect=1#comment135036199_76588520)
Fixed the code to support the secret reference.