### PR TITLE
fix!: replace random_id with random_string to increase number of possible access levels

### DIFF
--- a/modules/secure-serverless-harness/service_perimeter.tf
+++ b/modules/secure-serverless-harness/service_perimeter.tf
@@ -16,8 +16,8 @@
 
 locals {
   prefix                           = "secure_cloud_run"
-  access_level_name                = "alp_${local.prefix}_members_${random_id.random_access_level_suffix.hex}"
-  perimeter_name                   = "sp_${local.prefix}_perimeter_${random_id.random_access_level_suffix.hex}"
+  access_level_name                = "alp_${local.prefix}_members_${random_string.random_access_level_suffix.result}"
+  perimeter_name                   = "sp_${local.prefix}_perimeter_${random_string.random_access_level_suffix.result}"
   access_context_manager_policy_id = var.create_access_context_manager_access_policy ? google_access_context_manager_access_policy.access_policy[0].id : var.access_context_manager_policy_id
   access_level_members = concat(var.access_level_members,
     [for project in module.serverless_project : "serviceAccount:${project.services_identities["cloudbuild"]}"],
@@ -26,8 +26,12 @@ locals {
   )
 }
 
-resource "random_id" "random_access_level_suffix" {
-  byte_length = 2
+resource "random_string" "random_access_level_suffix" {
+  length  = 4
+  lower   = true
+  numeric = true
+  upper   = false
+  special = false
 }
 
 /******************************************


### PR DESCRIPTION
This PR  replaces the random_id used in the composition of the names of the Access Level and Perimeter created in the `secure-serverless-harness` so that instead of a space with `[0-9a-f](4)` we will have `[0-9a-z](4)` which will decrease the chance of a collision of names when running tests

```
Error: Error creating AccessPolicy: googleapi: Error 409: Policy already exists with parent organizations/00000000000000
```