### PR TITLE
feat: Adding support for mounting Cloud Storage buckets as volumes in the container

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -155,13 +155,21 @@ resource "google_cloud_run_service" "main" {
         content {
           name = volumes.value["name"]
           dynamic "secret" {
-            for_each = volumes.value.secret
+            for_each = volumes.value.secret == null ? toset([]) : volumes.value.secret
             content {
               secret_name = secret.value["secret_name"]
               items {
                 key  = secret.value.items["key"]
                 path = secret.value.items["path"]
               }
+            }
+          }
+          dynamic "csi" {
+            for_each = volumes.value.csi == null ? toset([]) : volumes.value.csi
+            content {
+              driver            = csi.value.driver
+              read_only         = csi.value.read_only
+              volume_attributes = csi.value.volume_attributes
             }
           }
         }

--- a/variables.tf
+++ b/variables.tf
@@ -117,10 +117,15 @@ variable "service_account_email" {
 variable "volumes" {
   type = list(object({
     name = string
-    secret = set(object({
+    secret = optional(set(object({
       secret_name = string
       items       = map(string)
-    }))
+    })))
+    csi = optional(set(object({
+      driver            = string
+      read_only         = optional(bool)
+      volume_attributes = optional(map(string))
+    })))
   }))
   description = "[Beta] Volumes needed for environment variables (when using secret)"
   default     = []


### PR DESCRIPTION
Cloud Run now offers the ability to mount a Cloud Storage bucket as a volume in the container. Also the Terraform provider in the google_cloud_run_service resource offers it: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service#csi.

This PR adds such support in the module.

This PR fixes issue #207