### PR TITLE
fix: Add connection metadata for incoming connection from GCS and fix typo in v2/main.tf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.22.8
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.22
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.22
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.22.8
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 
@@ -37,6 +37,7 @@ docker_test_lint:
 .PHONY: docker_generate_docs
 docker_generate_docs:
 	docker run --rm -it \
+		-e ENABLE_BPMETADATA \
 		-v $(CURDIR):/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs'

--- a/modules/v2/main.tf
+++ b/modules/v2/main.tf
@@ -28,8 +28,9 @@ locals {
 
   service_account_prefix = substr("${var.service_name}-${var.location}", 0, 27)
   service_account_output = local.create_service_account ? {
-    id    = google_service_account.sa[0].account_id,
-    email = google_service_account.sa[0].email
+    id     = google_service_account.sa[0].account_id,
+    email  = google_service_account.sa[0].email,
+    member = google_service_account.sa[0].member
   } : {}
 }
 
@@ -259,8 +260,8 @@ resource "google_cloud_run_v2_service" "main" {
         dynamic "gcs" {
           for_each = volumes.value.gcs[*]
           content {
-            bucket    = gcs.value["medium"]
-            read_only = gcs.value["size_limit"]
+            bucket    = gcs.value["bucket"]
+            read_only = gcs.value["read_only"]
           }
         }
         dynamic "nfs" {

--- a/modules/v2/metadata.yaml
+++ b/modules/v2/metadata.yaml
@@ -85,7 +85,7 @@ spec:
               ports = optional(object({
                 name           = optional(string, "http1")
                 container_port = optional(number, 8080)
-              }))
+              }), {})
               resources = optional(object({
                 limits = optional(object({
                   cpu    = optional(string)
@@ -136,30 +136,36 @@ spec:
             }))
         required: true
         connections:
-        - source:
-            source: github.com/terraform-google-modules/terraform-google-memorystore
-            version: v10.0.0
-          spec:
-            outputExpr: env_vars
-            inputPath: env_vars
-        - source:
-            source: github.com/terraform-google-modules/terraform-google-sql-db//modules/postgresql
-            version: v21.0.0
-          spec:
-            outputExpr: env_vars
-            inputPath: env_vars
-        - source:
-            source: github.com/terraform-google-modules/terraform-google-service-accounts//modules/simple-sa
-            version: v4.2.3
-          spec:
-            outputExpr: env_vars
-            inputPath: env_vars
-        - source:
-            source: github.com/GoogleCloudPlatform/terraform-google-cloud-run///modules/v2
-            version: v0.12.0
-          spec:
-            outputExpr: "{ \"SERVICE_ENDPOINT\": service_uri }"
-            inputPath: env_vars
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-memorystore
+              version: v10.0.0
+            spec:
+              outputExpr: env_vars
+              inputPath: env_vars
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-sql-db//modules/postgresql
+              version: v21.0.0
+            spec:
+              outputExpr: env_vars
+              inputPath: env_vars
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-sql-db//modules/mysql
+              version: v21.0.1
+            spec:
+              outputExpr: env_vars
+              inputPath: env_vars
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-service-accounts//modules/simple-sa
+              version: v4.2.3
+            spec:
+              outputExpr: env_vars
+              inputPath: env_vars
+          - source:
+              source: github.com/GoogleCloudPlatform/terraform-google-cloud-run///modules/v2
+              version: v0.12.0
+            spec:
+              outputExpr: "{ \"SERVICE_ENDPOINT\": service_uri }"
+              inputPath: env_vars
       - name: create_service_account
         description: Create a new service account for cloud run service
         varType: bool
@@ -207,11 +213,11 @@ spec:
         description: Email address of the IAM service account associated with the revision of the service
         varType: string
         connections:
-        - source:
-            source: github.com/terraform-google-modules/terraform-google-service-accounts//modules/simple-sa
-            version: v4.2.3
-          spec:
-            outputExpr: email
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-service-accounts//modules/simple-sa
+              version: v4.2.3
+            spec:
+              outputExpr: email
       - name: service_account_project_roles
         description: Roles to grant to the newly created cloud run SA in specified project. Should be used with create_service_account set to true and no input for service_account
         varType: list(string)
@@ -252,7 +258,6 @@ spec:
               min_instance_count = optional(number)
               max_instance_count = optional(number)
             })
-        defaultValue: {}
       - name: timeout
         description: Max allowed time for an instance to respond to a request. A duration in seconds with up to nine fractional digits, ending with 's'
         varType: string
@@ -299,12 +304,24 @@ spec:
             }))
         defaultValue: []
         connections:
-        - source:
-            source: github.com/q2w/terraform-google-sql-db//modules/postgresql
-            version: v21.0.0
-          spec:
-            outputExpr: instance_connection_name
-            inputPath: cloud_sql_instance.instances
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-sql-db//modules/postgresql
+              version: v21.0.0
+            spec:
+              outputExpr: instance_connection_name
+              inputPath: cloud_sql_instance.instances
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-sql-db//modules/mysql
+              version: v21.0.1
+            spec:
+              outputExpr: instance_connection_name
+              inputPath: cloud_sql_instance.instances
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-cloud-storage//modules/simple_bucket
+              version: v6.1.0
+            spec:
+              outputExpr: name
+              inputPath: gcs.bucket
       - name: vpc_access
         description: VPC Access configuration to use for this Task. For more information, visit https://cloud.google.com/run/docs/configuring/connecting-vpc
         varType: |-
@@ -317,14 +334,13 @@ spec:
                 tags       = optional(list(string))
               }))
             })
-        defaultValue: {}
         connections:
-        - source:
-            source: github.com/terraform-google-modules/terraform-google-network//modules/vpc-serverless-connector-beta
-            version: v9.1.0
-          spec:
-            outputExpr: one(connector_ids)
-            inputPath: connector
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-network//modules/vpc-serverless-connector-beta
+              version: v9.1.0
+            spec:
+              outputExpr: connector_ids
+              inputPath: connector
     outputs:
       - name: creator
         description: Email address of the authenticated creator.


### PR DESCRIPTION
This PR makes below changes,

1. Fixes typo in v2/main.tf for creating GCS volume fixes https://github.com/GoogleCloudPlatform/terraform-google-cloud-run/issues/230
2. Adds new connection metadata coming from GCS
3. Adds new connection metadata coming from Mysql (similar to existing postgresql module)
