### PR TITLE
fix: Error fix for v2 module due to missing tcp_socket attribute

### DIFF
--- a/modules/v2/variables.tf
+++ b/modules/v2/variables.tf
@@ -293,6 +293,9 @@ variable "containers" {
           value = string
         })), null)
       }), null)
+      tcp_socket = optional(object({
+        port = optional(number)
+      }), null)
       grpc = optional(object({
         port    = optional(number)
         service = optional(string)


### PR DESCRIPTION
## What I did

I added the `tcp_socket` attribute to the `variables.tf` of the `v2` modules.

## Errors

When I use the v2 module, I encountered the following error.

```bash
╷
│ Error: Unsupported attribute
│
│   on main.tf line 149, in resource "google_cloud_run_v2_service" "main":
│  149:               for_each = liveness_probe.value.tcp_socket[*]
│     ├────────────────
│     │ liveness_probe.value is object with 6 attributes
│
│ This object does not have an attribute named "tcp_socket".
```

## Why

There is a `tcp_socket` section on the `main.tf` ( https://github.com/GoogleCloudPlatform/terraform-google-cloud-run/blob/main/modules/v2/main.tf#L182-L187 ).
However, there is no `tcp_socket` section on the `variables.tf` ( https://github.com/GoogleCloudPlatform/terraform-google-cloud-run/blob/main/modules/v2/variables.tf#L283-L301 )

