### PR TITLE
fix: Update alternate default for vpc_access input of modules/v2

### DIFF
--- a/modules/v2/metadata.display.yaml
+++ b/modules/v2/metadata.display.yaml
@@ -137,10 +137,9 @@ spec:
           altDefaults:
             - type: ALTERNATE_TYPE_DC
               value:
-                  network_interface:
-                    network: "default"
-                    subnetwork: "default"
-
+                network_interfaces:
+                  network: default
+                  subnetwork: default
     runtime:
       outputs:
         service_uri:


### PR DESCRIPTION
The alternate default has typo in the fieldname. Changed it to match the input type.