### PR TITLE
fix: add connection metadata and display metadata

### DIFF
--- a/modules/v2/main.tf
+++ b/modules/v2/main.tf
@@ -24,7 +24,7 @@ locals {
       : null
     )
   )
-  create_service_account = var.service_account == null && var.create_service_account
+  create_service_account = var.create_service_account ? var.service_account == null : false
 
   service_account_prefix = substr("${var.service_name}-${var.location}", 0, 27)
   service_account_output = local.create_service_account ? {

--- a/modules/v2/metadata.display.yaml
+++ b/modules/v2/metadata.display.yaml
@@ -41,6 +41,11 @@ spec:
         containers:
           name: containers
           title: Containers
+          altDefaults:
+            - type: ALTERNATE_TYPE_DC
+              value:
+                - container_name: service-container
+                  container_image: us-docker.pkg.dev/cloudrun/container/hello
         create_service_account:
           name: create_service_account
           title: Create Service Account

--- a/modules/v2/metadata.display.yaml
+++ b/modules/v2/metadata.display.yaml
@@ -37,7 +37,7 @@ spec:
         cloud_run_deletion_protection:
           name: cloud_run_deletion_protection
           title: Cloud Run Deletion Protection
-          invisible: false
+          level: 1
         containers:
           name: containers
           title: Containers
@@ -49,18 +49,18 @@ spec:
         create_service_account:
           name: create_service_account
           title: Create Service Account
-          invisible: false
+          level: 1
         custom_audiences:
           name: custom_audiences
           title: Custom Audiences
         description:
           name: description
           title: Description
-          invisible: false
+          level: 1
         enable_prometheus_sidecar:
           name: enable_prometheus_sidecar
           title: Enable Prometheus Sidecar
-          invisible: false
+          level: 1
           altDefaults:
             - type: ALTERNATE_TYPE_DC
               value: true
@@ -85,7 +85,7 @@ spec:
         members:
           name: members
           title: Members
-          invisible: false
+          level: 1
         project_id:
           name: project_id
           title: Project Id
@@ -98,7 +98,7 @@ spec:
         service_account_project_roles:
           name: service_account_project_roles
           title: Service Account Project Roles
-          invisible: false
+          level: 1
         service_annotations:
           name: service_annotations
           title: Service Annotations
@@ -113,6 +113,7 @@ spec:
         service_scaling:
           name: service_scaling
           title: Service Scaling
+          level: 1
         session_affinity:
           name: session_affinity
           title: Session Affinity
@@ -134,11 +135,11 @@ spec:
         volumes:
           name: volumes
           title: Volumes
-          invisible: false
+          level: 1
         vpc_access:
           name: vpc_access
           title: Vpc Access
-          invisible: false
+          level: 1
           altDefaults:
             - type: ALTERNATE_TYPE_DC
               value:

--- a/modules/v2/metadata.yaml
+++ b/modules/v2/metadata.yaml
@@ -281,6 +281,12 @@ spec:
         description: Unstructured key value map that can be used to organize and categorize objects. For more information, visit https://cloud.google.com/resource-manager/docs/creating-managing-labels or https://cloud.google.com/run/docs/configuring/labels
         varType: map(string)
         defaultValue: {}
+        connections:
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-project-factory//modules/project_services
+              version: ">= 17.1.0"
+            spec:
+              outputExpr: "{\"vertex-ai\": \"true\"}"
       - name: service_annotations
         description: Unstructured key value map that may be set by external tools to store and arbitrary metadata. They are not queryable and should be preserved when modifying objects. Refer https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#annotations
         varType: map(string)


### PR DESCRIPTION
This PR makes below changes,
* Add connection metadata for connecting with vertex-ai dummy module
* updates metadata.display.yaml
* adds alternate default for containers