### PR TITLE
Fix: Remove deletion_protection variable argument

### DIFF
--- a/modules/v2/README.md
+++ b/modules/v2/README.md
@@ -17,7 +17,7 @@ Basic usage of this module is as follows:
 ```hcl
 module "cloud_run_core" {
   source  = "GoogleCloudPlatform/cloud-run/google//modules/v2"
-  version = "~> 0.11.0"
+  version = "~> 0.15.4"
 
   project_id      = var.project_id
   service_name    = "hello-world"

--- a/modules/v2/main.tf
+++ b/modules/v2/main.tf
@@ -86,8 +86,6 @@ resource "google_cloud_run_v2_service" "main" {
   description = var.description
   labels      = var.service_labels
 
-  deletion_protection = var.cloud_run_deletion_protection
-
   template {
     revision        = var.revision
     labels          = var.template_labels

--- a/modules/v2/variables.tf
+++ b/modules/v2/variables.tf
@@ -144,12 +144,6 @@ variable "vpc_access" {
   default     = null
 }
 
-variable "cloud_run_deletion_protection" {
-  type        = bool
-  description = "This field prevents Terraform from destroying or recreating the Cloud Run v2 Jobs and Services"
-  default     = true
-}
-
 // Prometheus sidecar
 variable "enable_prometheus_sidecar" {
   type        = bool


### PR DESCRIPTION
We are facing an issue with the new version of 0.15.3

Something is out of sync with the API and the [official documentation of Terraform](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#example-usage---cloudrunv2-service-basic) and the module.

Seems that `**deletion_protection**` is not expected on the resource "**google_cloud_run_v2_service**"

![image](https://github.com/user-attachments/assets/cd9fb0db-c3c9-4339-a2f0-03a8991e9447)

