### PR TITLE
fix: add lower version constraint to Terraform Google provider

### DIFF
--- a/modules/job-exec/versions.tf
+++ b/modules/job-exec/versions.tf
@@ -24,7 +24,7 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "< 7"
+      version = ">= 6, < 7"
     }
   }
   provider_meta "google" {

--- a/modules/secure-cloud-run-core/versions.tf
+++ b/modules/secure-cloud-run-core/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "< 7"
+      version = ">= 6, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "< 7"
+      version = ">= 6, < 7"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/secure-cloud-run-security/versions.tf
+++ b/modules/secure-cloud-run-security/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "< 7"
+      version = ">= 6, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "< 7"
+      version = ">= 6, < 7"
     }
   }
 

--- a/modules/secure-cloud-run/versions.tf
+++ b/modules/secure-cloud-run/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "< 7"
+      version = ">= 6, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "< 7"
+      version = ">= 6, < 7"
     }
   }
 

--- a/modules/secure-serverless-harness/versions.tf
+++ b/modules/secure-serverless-harness/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "< 7"
+      version = ">= 6, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "< 7"
+      version = ">= 6, < 7"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/secure-serverless-net/versions.tf
+++ b/modules/secure-serverless-net/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "< 7"
+      version = ">= 6, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "< 7"
+      version = ">= 6, < 7"
     }
   }
 

--- a/modules/service-project-factory/versions.tf
+++ b/modules/service-project-factory/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "< 7"
+      version = ">= 6, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "< 7"
+      version = ">= 6, < 7"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/v2/versions.tf
+++ b/modules/v2/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "< 7"
+      version = ">= 6, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "< 7"
+      version = ">= 6, < 7"
     }
   }
 

--- a/test/fixtures/secure_cloud_run/versions.tf
+++ b/test/fixtures/secure_cloud_run/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.53"
+      version = ">= 6, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.53"
+      version = ">= 6, < 7"
     }
   }
 }

--- a/test/fixtures/simple_cloud_run/versions.tf
+++ b/test/fixtures/simple_cloud_run/versions.tf
@@ -16,4 +16,15 @@
 
 terraform {
   required_version = ">= 0.13"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6, < 7"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 6, < 7"
+    }
+  }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "< 7"
+      version = ">= 6, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "< 7"
+      version = ">= 6, < 7"
     }
   }
 


### PR DESCRIPTION
add lower version constraint to Terraform Google provider (`deletion_protection` was added/required in TPG v6)

Fixes: https://github.com/GoogleCloudPlatform/terraform-google-cloud-run/pull/257, https://github.com/GoogleCloudPlatform/terraform-google-cloud-run/pull/275