### PR TITLE
fix: add test for cloud-run v2 with gmp container

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -116,6 +116,20 @@ steps:
 - id: v2-teardown
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'cft test run TestV2 --stage teardown --verbose']
+- id: v2-gmp-init
+  waitFor:
+    - v2-teardown
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestV2WithGMP --stage init --verbose']
+- id: v2-gmp-apply
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestV2WithGMP --stage apply --verbose']
+- id: v2-gmp-verify
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestV2WithGMP --stage verify --verbose']
+- id: v2-gmp-teardown
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestV2WithGMP --stage teardown --verbose']
 tags:
 - 'ci'
 - 'integration'

--- a/examples/v2_with_gmp/main.tf
+++ b/examples/v2_with_gmp/main.tf
@@ -27,5 +27,6 @@ module "cloud_run_v2" {
       container_name  = "hello-world"
     }
   ]
-  enable_prometheus_sidecar = true
+  enable_prometheus_sidecar     = true
+  cloud_run_deletion_protection = false
 }

--- a/modules/v2/metadata.yaml
+++ b/modules/v2/metadata.yaml
@@ -402,7 +402,8 @@ spec:
         description: Service URI in CAIS style to be used by Apphub.
         type:
           - object
-          - service_id: string
+          - location: string
+            service_id: string
             service_uri: string
       - name: creator
         description: Email address of the authenticated creator.
@@ -475,6 +476,7 @@ spec:
           - roles/iam.serviceAccountUser
           - roles/serviceusage.serviceUsageViewer
           - roles/cloudkms.admin
+          - roles/resourcemanager.projectIamAdmin
     services:
       - cloudresourcemanager.googleapis.com
       - storage-api.googleapis.com

--- a/modules/v2/outputs.tf
+++ b/modules/v2/outputs.tf
@@ -83,6 +83,7 @@ output "apphub_service_uri" {
   value = {
     service_uri = "//run.googleapis.com/${google_cloud_run_v2_service.main.id}"
     service_id  = substr("${var.service_name}-${md5("${var.location}-${var.project_id}")}", 0, 63)
+    location    = var.location
   }
   description = "Service URI in CAIS style to be used by Apphub."
 }

--- a/test/integration/v2_with_gmp/v2_with_gmp_test.go
+++ b/test/integration/v2_with_gmp/v2_with_gmp_test.go
@@ -1,0 +1,44 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2_with_gmp
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestV2WithGMP(t *testing.T) {
+	runV2GMP := tft.NewTFBlueprintTest(t)
+
+	runV2GMP.DefineVerify(func(assert *assert.Assertions) {
+		// runV2GMP.DefaultVerify(assert)
+
+		projectID := runV2GMP.GetTFSetupStringOutput("project_id")
+		serviceName := runV2GMP.GetStringOutput("service_name")
+		serviceLocation := runV2GMP.GetStringOutput("service_location")
+
+		runCmd := gcloud.Run(t, "run services describe", gcloud.WithCommonArgs([]string{serviceName, "--project", projectID, "--region", serviceLocation, "--format", "json"}))
+
+		// Verify the Cloud Run Service deployed is in ready state.
+		readyCondition := utils.GetFirstMatchResult(t, runCmd.Get("status").Get("conditions").Array(), "type", "Ready")
+		assert.Equal("True", readyCondition.Get("status").String(), fmt.Sprintf("Should be in ready status"))
+	})
+	runV2GMP.Test()
+}

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -21,7 +21,8 @@ locals {
     "roles/artifactregistry.admin",
     "roles/iam.serviceAccountUser",
     "roles/serviceusage.serviceUsageViewer",
-    "roles/cloudkms.admin"
+    "roles/cloudkms.admin",
+    "roles/resourcemanager.projectIamAdmin"
   ]
 
   folder_required_roles = [


### PR DESCRIPTION
In addition to adding test for cloud-run v2 with gmp, this PR makes below changes,

* Adds IAM role for deployment service account to assign roles to the cloud-run SA
* Adds location field in apphub_service_uri