### PR TITLE
fix: update service_account_id output variable

### DIFF
--- a/examples/v2/main.tf
+++ b/examples/v2/main.tf
@@ -14,13 +14,21 @@
  * limitations under the License.
  */
 
+resource "google_service_account" "sa" {
+  project      = var.project_id
+  account_id   = "ci-cloud-run-v2-sa"
+  display_name = "Service account for ci-cloud-run-v2"
+}
+
 module "cloud_run_v2" {
   source  = "GoogleCloudPlatform/cloud-run/google//modules/v2"
   version = "~> 0.16"
 
-  service_name = "ci-cloud-run-v2"
-  project_id   = var.project_id
-  location     = "us-central1"
+  service_name           = "ci-cloud-run-v2"
+  project_id             = var.project_id
+  location               = "us-central1"
+  create_service_account = false
+  service_account        = google_service_account.sa.email
 
   cloud_run_deletion_protection = var.cloud_run_deletion_protection
 

--- a/modules/v2/main.tf
+++ b/modules/v2/main.tf
@@ -15,6 +15,7 @@
  */
 
 data "google_service_account" "existing_sa" {
+  count      = local.create_service_account == false ? 1 : 0
   account_id = element(split("@", google_cloud_run_v2_service.main.template[0].service_account), 0)
   project    = element(split("@", element(split(".", google_cloud_run_v2_service.main.template[0].service_account), 0)), 1)
 }
@@ -32,10 +33,14 @@ locals {
   create_service_account = var.create_service_account ? var.service_account == null : false
 
   service_account_prefix = substr("${var.service_name}-${var.location}", 0, 27)
-  service_account_output = {
-    id     = data.google_service_account.existing_sa.account_id,
-    email  = data.google_service_account.existing_sa.email,
-    member = data.google_service_account.existing_sa.member
+  service_account_output = local.create_service_account ? {
+    id     = google_service_account.sa[0].account_id,
+    email  = google_service_account.sa[0].email,
+    member = google_service_account.sa[0].member
+    } : {
+    id     = data.google_service_account.existing_sa[0].account_id,
+    email  = data.google_service_account.existing_sa[0].email,
+    member = data.google_service_account.existing_sa[0].member
   }
 
   ingress_container = try(

--- a/modules/v2/main.tf
+++ b/modules/v2/main.tf
@@ -16,8 +16,7 @@
 
 data "google_service_account" "existing_sa" {
   count      = local.create_service_account == false ? 1 : 0
-  account_id = element(split("@", google_cloud_run_v2_service.main.template[0].service_account), 0)
-  project    = element(split("@", element(split(".", google_cloud_run_v2_service.main.template[0].service_account), 0)), 1)
+  account_id = google_cloud_run_v2_service.main.template[0].service_account
 }
 
 locals {

--- a/modules/v2/main.tf
+++ b/modules/v2/main.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+data "google_service_account" "existing_sa" {
+  account_id = element(split("@", google_cloud_run_v2_service.main.template[0].service_account), 0)
+  project    = element(split("@", element(split(".", google_cloud_run_v2_service.main.template[0].service_account), 0)), 1)
+}
+
 locals {
   service_account = (
     var.service_account != null
@@ -27,11 +32,11 @@ locals {
   create_service_account = var.create_service_account ? var.service_account == null : false
 
   service_account_prefix = substr("${var.service_name}-${var.location}", 0, 27)
-  service_account_output = local.create_service_account ? {
-    id     = google_service_account.sa[0].account_id,
-    email  = google_service_account.sa[0].email,
-    member = google_service_account.sa[0].member
-  } : {}
+  service_account_output = {
+    id     = data.google_service_account.existing_sa.account_id,
+    email  = data.google_service_account.existing_sa.email,
+    member = data.google_service_account.existing_sa.member
+  }
 
   ingress_container = try(
     [for container in var.containers : container if length(try(container.ports, {})) > 0][0],

--- a/modules/v2/metadata.yaml
+++ b/modules/v2/metadata.yaml
@@ -255,6 +255,11 @@ spec:
               version: ^10.0
             spec:
               outputExpr: "[\"roles/bigquery.dataEditor\"]"
+          - source:
+              source: github.com/GoogleCloudPlatform/terraform-google-bigtable
+              version: ">= 0.1.0"
+            spec:
+              outputExpr: "[\"roles/bigtable.admin\"]"
       - name: members
         description: "Users/SAs to be given invoker access to the service. Grant invoker access by specifying the users or service accounts (SAs). Use allUsers for public access, allAuthenticatedUsers for access by logged-in Google users, or provide a list of specific users/SAs. See the complete list of available options: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service_iam#member\\/members-1"
         varType: list(string)


### PR DESCRIPTION
With this change, service_accout_id would always be present even if the service_account creation is disabled as part of the cloud-run blueprint.

This PR also update to skip assigning any roles is SA is not created by the blueprint. When a user provides as SA, they are in control for assigning any roles. b/396010348