### PR TITLE
chore: Add bigtable connection metadata

### DIFF
--- a/modules/v2/metadata.yaml
+++ b/modules/v2/metadata.yaml
@@ -195,6 +195,12 @@ spec:
             spec:
               outputExpr: "{\"BIGQUERY_DATASET\" : env_vars.BIGQUERY_DATASET, \"BIGQUERY_TABLES\" : env_vars.BIGQUERY_TABLES, \"BIGQUERY_VIEWS\" : env_vars.BIGQUERY_VIEWS, \"BIGQUERY_MATERIALIZED_VIEWS\" : env_vars.BIGQUERY_MATERIALIZED_VIEWS, \"BIGQUERY_EXTERNAL_TABLES\" : env_vars.BIGQUERY_EXTERNAL_TABLES, \"BIGQUERY_ROUTINES\" : env_vars.BIGQUERY_ROUTINES}"
               inputPath: env_vars
+          - source:
+              source: github.com/GoogleCloudPlatform/terraform-google-bigtable
+              version: ">= 0.1.0"
+            spec:
+              outputExpr: "{\"BIGTABLE_INSTANCE_ID\" : instance_id, \"BIGTABLE_TABLE_IDS\" : table_ids}"
+              inputPath: env_vars
       - name: create_service_account
         description: Create a new service account for cloud run service
         varType: bool


### PR DESCRIPTION
Adding connection metadata for cloud bigtable. Bigtable outputs can be verified at https://github.com/GoogleCloudPlatform/terraform-google-bigtable/blob/main/outputs.tf.