### PR TITLE
feat(cloudrun-job): Allow defining network interfaces

### DIFF
--- a/modules/job-exec/main.tf
+++ b/modules/job-exec/main.tf
@@ -90,8 +90,17 @@ resource "google_cloud_run_v2_job" "job" {
         content {
           connector = vpc_access.value["connector"]
           egress    = vpc_access.value["egress"]
+          dynamic "network_interfaces" {
+            for_each = vpc_access.value["network_interfaces"]
+            content {
+              network    = network_interfaces.value["network"]
+              subnetwork = network_interfaces.value["subnetwork"]
+              tags       = network_interfaces.value["tags"]
+            }
+          }
         }
       }
+    }
     }
   }
 }

--- a/modules/job-exec/variables.tf
+++ b/modules/job-exec/variables.tf
@@ -135,6 +135,11 @@ variable "vpc_access" {
   type = list(object({
     connector = string
     egress    = string
+    network_interfaces = optional(object({
+      network    = optional(string)
+      subnetwork = optional(string)
+      tags       = optional(list(string))
+    }))
   }))
   description = "VPC Access configuration to use for this Task."
   default     = []


### PR DESCRIPTION
The terraform resource allows defining network interfaces but the module does not. Allow this capability to specify the network and subnetwork directly.

You can see the argument reference here https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_job#argument-reference

And the cloudrun module already supports it https://github.com/GoogleCloudPlatform/terraform-google-cloud-run/blob/v0.16.4/modules/v2/variables.tf#L137-L141

Want a similar behavior for cloudrun job.