### PR TITLE
chore: grant run.invoker role when connection to pubsub

### DIFF
--- a/modules/v2/metadata.yaml
+++ b/modules/v2/metadata.yaml
@@ -250,7 +250,7 @@ spec:
               source: github.com/terraform-google-modules/terraform-google-pubsub
               version: ">= 7.0.0"
             spec:
-              outputExpr: "[\"roles/pubsub.publisher\", \"roles/pubsub.subscriber\"]"
+              outputExpr: "[\"roles/pubsub.publisher\", \"roles/pubsub.subscriber\", \"roles/run.invoker\"]"
           - source:
               source: github.com/GoogleCloudPlatform/terraform-google-cloud-spanner
               version: ">= 1.1.1"


### PR DESCRIPTION
`roles/run.invoker` is required for 

The oidc-service-account email used for

The push subscription created via an Cloud Run -> Pub/Sub ADC connection requires a service account with `roles/run.invoker`. We satisfy this requirement by granting `roles/run.invoker` to the Cloud Run service account.