### PR TITLE
feat: Add connections for Memorystore in metadata.yaml

### DIFF
--- a/modules/v2/metadata.yaml
+++ b/modules/v2/metadata.yaml
@@ -147,6 +147,12 @@ spec:
         required: true
         connections:
           - source:
+              source: github.com/terraform-google-modules/terraform-google-memorystore/tree/main/modules/redis-cluster
+              version: ">= 12.0"
+            spec:
+              outputExpr: "{\"REDIS_CLUSTER_ENDPOINT\":discovery_endpoints}"
+              inputPath: env_vars
+          - source:
               source: github.com/terraform-google-modules/terraform-google-memorystore
               version: ">= 12.0"
             spec:
@@ -263,6 +269,11 @@ spec:
               version: ">= 12.0"
             spec:
               outputExpr: "[\"roles/redis.editor\"]"
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-memorystore/tree/main/modules/redis-cluster
+              version: ">= 12.0"
+            spec:
+              outputExpr: "[\"roles/redis.dbConnectionUser\"]"
           - source:
               source: github.com/GoogleCloudPlatform/terraform-google-cloud-run//modules/v2
               version: ">= 0.13"

--- a/modules/v2/metadata.yaml
+++ b/modules/v2/metadata.yaml
@@ -150,7 +150,7 @@ spec:
               source: github.com/terraform-google-modules/terraform-google-memorystore/tree/main/modules/redis-cluster
               version: ">= 12.0"
             spec:
-              outputExpr: "{\"REDIS_CLUSTER_ENDPOINT\":discovery_endpoints}"
+              outputExpr: "{\"REDIS_CLUSTER_HOST\": env_vars.REDIS_CLUSTER_HOST, \"REDIS_CLUSTER_PORT\": env_vars.REDIS_CLUSTER_PORT}"
               inputPath: env_vars
           - source:
               source: github.com/terraform-google-modules/terraform-google-memorystore


### PR DESCRIPTION
This PR establishes the necessary connections with Memorystore's GitHub repository.

Purpose: This is an essential step in adding connection_metadata for Memorystore Redis Clusters (MRC), a crucial part of our process to onboard MRC to Application Design Center (ADC). 