### PR TITLE
fix: trigger google_compute_default_service_account datasource only if the service account name is not provided

### DIFF
--- a/modules/v2/main.tf
+++ b/modules/v2/main.tf
@@ -15,7 +15,7 @@
  */
 
 data "google_compute_default_service_account" "default" {
-  count   = local.create_service_account == false ? 1 : 0
+  count   = local.create_service_account == false && var.service_account == null ? 1 : 0
   project = var.project_id
 }
 


### PR DESCRIPTION
This PR addresses the bug reported in https://github.com/GoogleCloudPlatform/terraform-google-cloud-run/issues/360