### PR TITLE
feat(job-exec): add support of Direct VPC egress

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -321,13 +321,13 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/iam.serviceAccountAdmin
           - roles/artifactregistry.admin
           - roles/iam.serviceAccountUser
           - roles/serviceusage.serviceUsageViewer
           - roles/cloudkms.admin
           - roles/resourcemanager.projectIamAdmin
           - roles/run.admin
-          - roles/iam.serviceAccountAdmin
     services:
       - accesscontextmanager.googleapis.com
       - cloudbilling.googleapis.com

--- a/modules/job-exec/README.md
+++ b/modules/job-exec/README.md
@@ -55,7 +55,7 @@ Functional examples are included in the
 | timeout | Max allowed time duration the Task may be active before the system will actively try to mark it failed and kill associated containers. | `string` | `"600s"` | no |
 | volume\_mounts | Volume to mount into the container's filesystem. | <pre>list(object({<br>    name       = string<br>    mount_path = string<br>  }))</pre> | `[]` | no |
 | volumes | A list of Volumes to make available to containers. | <pre>list(object({<br>    name = string<br>    cloud_sql_instance = optional(object({<br>      instances = set(string)<br>    }))<br>    gcs = optional(object({<br>      bucket        = string<br>      read_only     = optional(bool)<br>      mount_options = optional(list(string))<br>    }))<br>  }))</pre> | `[]` | no |
-| vpc\_access | VPC Access configuration to use for this Task. | <pre>list(object({<br>    connector = string<br>    egress    = string<br>  }))</pre> | `[]` | no |
+| vpc\_access | Configure this to enable your service to send traffic to a Virtual Private Cloud. Set egress to ALL\_TRAFFIC or PRIVATE\_RANGES\_ONLY. Choose a connector or network\_interfaces (for direct VPC egress). [More info](https://cloud.google.com/run/docs/configuring/connecting-vpc) | <pre>object({<br>    connector = optional(string)<br>    egress    = optional(string)<br>    network_interfaces = optional(object({<br>      network    = optional(string)<br>      subnetwork = optional(string)<br>      tags       = optional(list(string))<br>    }))<br>  })</pre> | `null` | no |
 
 ## Outputs
 

--- a/modules/job-exec/main.tf
+++ b/modules/job-exec/main.tf
@@ -98,10 +98,18 @@ resource "google_cloud_run_v2_job" "job" {
       }
 
       dynamic "vpc_access" {
-        for_each = var.vpc_access
+        for_each = var.vpc_access != null ? [var.vpc_access] : []
         content {
           connector = vpc_access.value["connector"]
           egress    = vpc_access.value["egress"]
+          dynamic "network_interfaces" {
+            for_each = var.vpc_access.network_interfaces != null ? [var.vpc_access.network_interfaces] : []
+            content {
+              network    = network_interfaces.value["network"]
+              subnetwork = network_interfaces.value["subnetwork"]
+              tags       = network_interfaces.value["tags"]
+            }
+          }
         }
       }
     }

--- a/modules/job-exec/metadata.yaml
+++ b/modules/job-exec/metadata.yaml
@@ -173,13 +173,17 @@ spec:
             }))
         defaultValue: []
       - name: vpc_access
-        description: VPC Access configuration to use for this Task.
+        description: Configure this to enable your service to send traffic to a Virtual Private Cloud. Set egress to ALL_TRAFFIC or PRIVATE_RANGES_ONLY. Choose a connector or network_interfaces (for direct VPC egress). [More info](https://cloud.google.com/run/docs/configuring/connecting-vpc)
         varType: |-
-          list(object({
-              connector = string
-              egress    = string
-            }))
-        defaultValue: []
+          object({
+              connector = optional(string)
+              egress    = optional(string)
+              network_interfaces = optional(object({
+                network    = optional(string)
+                subnetwork = optional(string)
+                tags       = optional(list(string))
+              }))
+            })
       - name: limits
         description: Resource limits to the container
         varType: |-
@@ -203,13 +207,13 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/cloudkms.admin
           - roles/resourcemanager.projectIamAdmin
           - roles/run.admin
           - roles/iam.serviceAccountAdmin
           - roles/artifactregistry.admin
           - roles/iam.serviceAccountUser
           - roles/serviceusage.serviceUsageViewer
-          - roles/cloudkms.admin
     services:
       - accesscontextmanager.googleapis.com
       - cloudbilling.googleapis.com

--- a/modules/job-exec/variables.tf
+++ b/modules/job-exec/variables.tf
@@ -137,12 +137,17 @@ variable "volume_mounts" {
 }
 
 variable "vpc_access" {
-  type = list(object({
-    connector = string
-    egress    = string
-  }))
-  description = "VPC Access configuration to use for this Task."
-  default     = []
+  type = object({
+    connector = optional(string)
+    egress    = optional(string)
+    network_interfaces = optional(object({
+      network    = optional(string)
+      subnetwork = optional(string)
+      tags       = optional(list(string))
+    }))
+  })
+  description = "Configure this to enable your service to send traffic to a Virtual Private Cloud. Set egress to ALL_TRAFFIC or PRIVATE_RANGES_ONLY. Choose a connector or network_interfaces (for direct VPC egress). [More info](https://cloud.google.com/run/docs/configuring/connecting-vpc)"
+  default     = null
 }
 
 variable "limits" {

--- a/modules/secure-cloud-run-security/metadata.yaml
+++ b/modules/secure-cloud-run-security/metadata.yaml
@@ -131,13 +131,13 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/iam.serviceAccountUser
-          - roles/serviceusage.serviceUsageViewer
-          - roles/cloudkms.admin
           - roles/resourcemanager.projectIamAdmin
           - roles/run.admin
           - roles/iam.serviceAccountAdmin
           - roles/artifactregistry.admin
+          - roles/iam.serviceAccountUser
+          - roles/serviceusage.serviceUsageViewer
+          - roles/cloudkms.admin
     services:
       - accesscontextmanager.googleapis.com
       - cloudbilling.googleapis.com

--- a/modules/secure-serverless-harness/metadata.yaml
+++ b/modules/secure-serverless-harness/metadata.yaml
@@ -280,13 +280,13 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/run.admin
-          - roles/iam.serviceAccountAdmin
           - roles/artifactregistry.admin
           - roles/iam.serviceAccountUser
           - roles/serviceusage.serviceUsageViewer
           - roles/cloudkms.admin
           - roles/resourcemanager.projectIamAdmin
+          - roles/run.admin
+          - roles/iam.serviceAccountAdmin
     services:
       - accesscontextmanager.googleapis.com
       - cloudbilling.googleapis.com

--- a/modules/v2/metadata.yaml
+++ b/modules/v2/metadata.yaml
@@ -563,13 +563,13 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/run.admin
+          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
           - roles/serviceusage.serviceUsageViewer
           - roles/resourcemanager.projectIamAdmin
           - roles/compute.viewer
           - roles/iap.admin
-          - roles/run.admin
-          - roles/iam.serviceAccountAdmin
     services:
       - cloudresourcemanager.googleapis.com
       - compute.googleapis.com


### PR DESCRIPTION
_Reissue due to a mistake on my part. It seems that not everyone followed the contributor's guide, which introduced changes to other components that I did not want to modify (there was some drift)._

Hello,

Two PRs already exist, but seem to have been abandoned by their authors (https://github.com/GoogleCloudPlatform/terraform-google-cloud-run/pull/314 & https://github.com/GoogleCloudPlatform/terraform-google-cloud-run/pull/320).

The purpose of this PR is to activate this functionality, which has been available for several months now, for the “job-exec” submodule.

Thanks