### PR TITLE
Feat:add-client-variable-job-exec

### DIFF
--- a/modules/job-exec/main.tf
+++ b/modules/job-exec/main.tf
@@ -15,11 +15,13 @@
  */
 
 resource "google_cloud_run_v2_job" "job" {
-  name         = var.name
-  project      = var.project_id
-  location     = var.location
-  launch_stage = var.launch_stage
-  labels       = var.labels
+  name           = var.name
+  project        = var.project_id
+  location       = var.location
+  launch_stage   = var.launch_stage
+  labels         = var.labels
+  client         = var.client.name
+  client_version = var.client.version
 
   deletion_protection = var.cloud_run_deletion_protection
 

--- a/modules/job-exec/variables.tf
+++ b/modules/job-exec/variables.tf
@@ -169,3 +169,12 @@ variable "cloud_run_deletion_protection" {
   description = "This field prevents Terraform from destroying or recreating the Cloud Run v2 Jobs and Services"
   default     = true
 }
+
+variable "client" {
+  type = object({
+    name    = optional(string, null)
+    version = optional(string, null)
+  })
+  description = "Arbitrary identifier for the API client and version identifier"
+  default     = {}
+}


### PR DESCRIPTION
What
Add support for specifying an arbitrary API client identifier and version for google_cloud_run_v2_job resources.

Changes

Added client and client_version arguments to the google_cloud_run_v2_job resource in main.tf.

Introduced a new client variable (object) with optional name and version fields in variables.tf.

Updated default value for client to an empty object.

Why
This allows providing metadata for API client identification when creating or managing Cloud Run jobs, improving traceability and integration consistency.

