### PR TITLE
fix: remove alpha-documentai.googleapis.com from the list of VPC_SC restricted service

### DIFF
--- a/modules/secure-serverless-harness/service_perimeter.tf
+++ b/modules/secure-serverless-harness/service_perimeter.tf
@@ -69,7 +69,6 @@ module "regular_service_perimeter" {
     "adsdatahub.googleapis.com",
     "aiplatform.googleapis.com",
     "alloydb.googleapis.com",
-    "alpha-documentai.googleapis.com",
     "analyticshub.googleapis.com",
     "apigee.googleapis.com",
     "apigeeconnect.googleapis.com",

--- a/test/integration/secure_cloud_run_standalone/secure_cloud_run_standalone_test.go
+++ b/test/integration/secure_cloud_run_standalone/secure_cloud_run_standalone_test.go
@@ -61,7 +61,6 @@ func TestSecureCloudRunStandalone(t *testing.T) {
 		"adsdatahub.googleapis.com",
 		"aiplatform.googleapis.com",
 		"alloydb.googleapis.com",
-		"alpha-documentai.googleapis.com",
 		"analyticshub.googleapis.com",
 		"apigee.googleapis.com",
 		"apigeeconnect.googleapis.com",


### PR DESCRIPTION
This PR removes alpha-documentai.googleapis.com from the list of VPC_SC restricted service since it is no longer supported