### PR TITLE
feat: ignore Github Actions client

### DIFF
--- a/modules/v2/main.tf
+++ b/modules/v2/main.tf
@@ -372,6 +372,14 @@ resource "google_cloud_run_v2_service" "main" {
     }
   }
   depends_on = [google_project_iam_member.roles]
+
+  lifecycle {
+    ignore_changes = [
+      client,
+      client_version,
+      template[0].labels
+    ]
+  }
 }
 
 resource "google_cloud_run_v2_service_iam_member" "authorize" {


### PR DESCRIPTION
My use case is that I use the module to create a Cloud Run instance and then a Github Actions pipeline to deploy subsequent revisions.
The problem is that Github Actions deployment adds several new fields (like `client_version`) to the resource, which causes state drift:

```
  ~ resource "google_cloud_run_v2_service" "main" {
      - client                  = "gcloud" -> null
      - client_version          = "548.0.0" -> null
        id                      = "xyz"
        name                    = "xyz"
        # (35 unchanged attributes hidden)

      ~ template {
          ~ labels                           = {
              - "commit-sha"                 = "c6fafd63075cb23b53e763e427e877dd8669f999" -> null
              - "goog-terraform-provisioned" = "true" -> null
              - "managed-by"                 = "github-actions" -> null
            }
            # (9 unchanged attributes hidden)
            }

            # (1 unchanged block hidden)
        }

        # (2 unchanged blocks hidden)
    }
```

This small change adds `lifecycle_ignore` to ignore those changes. Identical code is already present in `v1` resource version of the module: https://github.com/GoogleCloudPlatform/terraform-google-cloud-run/blob/main/main.tf#L191