### PR TITLE
fix: Update filestore source in metadata.yaml

### DIFF
--- a/modules/v2/metadata.yaml
+++ b/modules/v2/metadata.yaml
@@ -244,12 +244,6 @@ spec:
             spec:
               outputExpr: "{\"ARTIFACT_REGISTRY_REPOSITORY_ID\": artifact_id}"
               inputPath: env_vars
-          - source:
-              source: github.com/GoogleCloudPlatform/terraform-google-cloud-filestore
-              version: ">= 0.1.0"
-            spec:
-              outputExpr: "{\"FILESTORE_MOUNT_POINT\": mount_point}"
-              inputPath: env_vars
       - name: node_selector
         description: Node Selector describes the hardware requirements of the GPU resource. [More info](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#nested_template_node_selector).
         varType: |-
@@ -439,6 +433,12 @@ spec:
             spec:
               outputExpr: name
               inputPath: gcs.bucket
+          - source:
+              source: github.com/GoogleCloudPlatform/terraform-google-cloud-filestore
+              version: ">= 0.1.0"
+            spec:
+              outputExpr: "{\"server\": instance_ip_address, \"path\": share_name}"
+              inputPath: nfs
       - name: traffic
         description: Specifies how to distribute traffic over a collection of Revisions belonging to the Service. If traffic is empty or not provided, defaults to 100% traffic to the latest Ready Revision.
         varType: |-


### PR DESCRIPTION
fix: Update filestore source in metadata.yaml with share and IP instead of mountpoint

Aligned Filestore source according to https://docs.cloud.google.com/run/docs/configuring/services/nfs-volume-mounts