### PR TITLE
fix: testPR_fixing drift in verify state because of null vs 0 diff

### DIFF
--- a/modules/v2/main.tf
+++ b/modules/v2/main.tf
@@ -358,7 +358,8 @@ resource "google_cloud_run_v2_service" "main" {
   dynamic "scaling" {
     for_each = var.service_scaling[*]
     content {
-      min_instance_count = scaling.value.min_instance_count
+      min_instance_count    = try(scaling.value.min_instance_count, 0)
+      manual_instance_count = 0
     }
   }
 


### PR DESCRIPTION
[testPR]
trying to default to 0 when changes are made in first place, in case the values are not provided related to scaling. this might resolve the issue which verify is creating 