### PR TITLE
feat: Add missing Agent Engine connection for Cloud Run

### DIFF
--- a/modules/v2/metadata.yaml
+++ b/modules/v2/metadata.yaml
@@ -274,6 +274,18 @@ spec:
             spec:
               outputExpr: "{\"DOCUMENT_AI_PROCESSOR_ID\": processor_id}"
               inputPath: env_vars
+          - source:
+              source: github.com/GoogleCloudPlatform/terraform-google-vertex-ai//modules/agent-engine-nightly
+              version: ">= 5.3.2"
+            spec:
+              outputExpr: "{\"VERTEX_AI_AGENT_ENGINE_URL\": reasoning_engine_url}"
+              inputPath: env_vars
+          - source:
+              source: github.com/GoogleCloudPlatform/terraform-google-vertex-ai//modules/agent-engine
+              version: ">= 5.3.2"
+            spec:
+              outputExpr: "{\"VERTEX_AI_AGENT_ENGINE_URL\": reasoning_engine_url}"
+              inputPath: env_vars
       - name: node_selector
         description: Node Selector describes the hardware requirements of the GPU resource. [More info](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#nested_template_node_selector).
         varType: |-
@@ -388,6 +400,16 @@ spec:
               version: ">= 0.0.1"
             spec:
               outputExpr: "[\"roles/documentai.admin\"]"
+          - source:
+              source: github.com/GoogleCloudPlatform/terraform-google-vertex-ai//modules/agent-engine-nightly
+              version: ">= 5.3.2"
+            spec:
+              outputExpr: "[\"roles/aiplatform.user\"]"
+          - source:
+              source: github.com/GoogleCloudPlatform/terraform-google-vertex-ai//modules/agent-engine
+              version: ">= 5.3.2"
+            spec:
+              outputExpr: "[\"roles/aiplatform.user\"]"
       - name: ingress
         description: Restricts network access to your Cloud Run service
         varType: string


### PR DESCRIPTION
Adding missing Agent Engine connection for Cloud Run.

Testing Steps for Agent Engine Connection:

Used the Automation script for implementing missing connections in ADC to perform the below steps:

1) Ingest Component Revision (BYOC):
a) Set the gcloud configuration to point to the Staging environment.
b) Create the template metadata for the Cloud Run component.
c) Create a template revision to pull our specific code tag (e.g., v0.27.0) into the private catalog.

2) Adding components and connections and filling up param values:
a) In the ADC canvas, add the custom Cloud Run and Agent Engine components.
b) Add a connection line between the two. This stage also passed successfully.
c) Fill all required configuration parameters for all 2 components (e.g., region, project, name, etc)

3) App Deployment:
a) Create a new application with the connected components.
b) Deploy and ensure the application deployment completes successfully.
c) Iterate in case of failures, trying with different values.

Successful testing in Staging environment:
https://screenshot.googleplex.com/6N3ferTZaCRXNVS

Connection Params:
https://screenshot.googleplex.com/z2Pm27Sb2hCAcci

Attaching the Deployment logs for reference:
https://paste.googleplex.com/6542239187730432