### PR TITLE
feat: Add missing Model Armor Template connection for Cloud Run

### DIFF
--- a/modules/v2/metadata.yaml
+++ b/modules/v2/metadata.yaml
@@ -286,6 +286,12 @@ spec:
             spec:
               outputExpr: "{\"VERTEX_AI_AGENT_ENGINE_URL\": reasoning_engine_url}"
               inputPath: env_vars
+          - source:
+              source: github.com/GoogleCloudPlatform/terraform-google-vertex-ai//modules/model-armor-template
+              version: v5.2.0
+            spec:
+              outputExpr: "{\"MODEL_ARMOR_TEMPLATE_ID\": template_id}"
+              inputPath: env_vars
       - name: node_selector
         description: Node Selector describes the hardware requirements of the GPU resource. [More info](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#nested_template_node_selector).
         varType: |-
@@ -410,6 +416,11 @@ spec:
               version: ">= 5.3.2"
             spec:
               outputExpr: "[\"roles/aiplatform.user\"]"
+          - source:
+              source: github.com/GoogleCloudPlatform/terraform-google-vertex-ai//modules/model-armor-template
+              version: v5.2.0
+            spec:
+              outputExpr: "[\"roles/modelarmor.viewer\"]"
       - name: ingress
         description: Restricts network access to your Cloud Run service
         varType: string


### PR DESCRIPTION
Adding missing Model Armor Template connection for Cloud Run.

Testing Steps for Model Armor Template Connection:

Used the Automation script for implementing missing connections in ADC to perform the below steps:

Ingest Component Revision (BYOC):
a) Set the gcloud configuration to point to the Staging environment.
b) Create the template metadata for the Cloud Run component.
c) Create a template revision to pull our specific code tag (e.g., v0.28.0) into the private catalog.

Adding components and connections and filling up param values:
a) In the ADC canvas, add the custom Cloud Run and Model Armor Template components.
b) Add a connection line between the two. This stage also passed successfully.
c) Fill all required configuration parameters for all 2 components (e.g., region, project, name, etc)

App Deployment:
a) Create a new application with the connected components.
b) Deploy and ensure the application deployment completes successfully.
c) Iterate in case of failures, trying with different values.

Successful testing in Staging environment:
https://screenshot.googleplex.com/8jbrpSgNUyJ87eu

Connection Params:
https://screenshot.googleplex.com/8uCbpM8rVSULNay

Attaching the Deployment logs for reference:
https://paste.googleplex.com/5826884735729664