### PR TITLE
fix!: update prometheus sidecar image to latest

### DIFF
--- a/modules/v2/main.tf
+++ b/modules/v2/main.tf
@@ -58,7 +58,7 @@ locals {
   )
   prometheus_sidecar_container = [{
     container_name  = "collector"
-    container_image = "us-docker.pkg.dev/cloud-ops-agents-artifacts/cloud-run-gmp-sidecar/cloud-run-gmp-sidecar:1.1.1"
+    container_image = "us-docker.pkg.dev/cloud-ops-agents-artifacts/cloud-run-gmp-sidecar/cloud-run-gmp-sidecar:latest"
     # Set default values for the sidecar container
     ports                = {}
     working_dir          = null


### PR DESCRIPTION
Updating the version of [us-docker.pkg.dev/cloud-ops-agents-artifacts/cloud-run-gmp-sidecar](https://www.google.com/url?sa=D&q=http%3A%2F%2Fus-docker.pkg.dev%2Fcloud-ops-agents-artifacts%2Fcloud-run-gmp-sidecar) image to use the 'latest' instead of 1.1.1

Test: https://screenshot.googleplex.com/4syHbB2xGW2W6GA