### PR TITLE
feat: add connection with Valkey Cluster

### DIFF
--- a/modules/v2/metadata.yaml
+++ b/modules/v2/metadata.yaml
@@ -150,9 +150,15 @@ spec:
         connections:
           - source:
               source: github.com/terraform-google-modules/terraform-google-memorystore//modules/redis-cluster
-              version: ">= 12.0"
+              version: ">= 15.1.0"
             spec:
               outputExpr: "{\"REDIS_CLUSTER_HOST\": env_vars.REDIS_CLUSTER_HOST, \"REDIS_CLUSTER_PORT\": env_vars.REDIS_CLUSTER_PORT}"
+              inputPath: env_vars
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-memorystore//modules/valkey
+              version: ">= 16.2.0"
+            spec:
+              outputExpr: "{\"VALKEY_HOST\": env_vars.VALKEY_HOST, \"VALKEY_PORT\": env_vars.VALKEY_PORT}"
               inputPath: env_vars
           - source:
               source: github.com/terraform-google-modules/terraform-google-memorystore
@@ -338,8 +344,13 @@ spec:
             spec:
               outputExpr: "[\"roles/redis.editor\"]"
           - source:
+              source: github.com/terraform-google-modules/terraform-google-memorystore//modules/valkey
+              version: ">= 16.2.0"
+            spec:
+              outputExpr: "[\"roles/memorystore.dbConnectionUser\"]"
+          - source:
               source: github.com/terraform-google-modules/terraform-google-memorystore//modules/redis-cluster
-              version: ">= 12.0"
+              version: ">= 15.1.0"
             spec:
               outputExpr: "[\"roles/redis.dbConnectionUser\"]"
           - source:


### PR DESCRIPTION
Adding connection metadata for Valkey Cluster. For reference refer to similar change done for redis cluster

already added these variables in output.tf for valkey module